### PR TITLE
updated to java 21 as it was failing on Homeassistant yellow HAOS 202…

### DIFF
--- a/devismart-mqtt/Dockerfile
+++ b/devismart-mqtt/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM AS build
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=21
 
 LABEL org.opencontainers.image.description="$(cat README.md)"
 
@@ -27,8 +27,8 @@ RUN mv ./ha-devi-mqtt/pom.xml ./pom.xml
 RUN mv ./ha-devi-mqtt/auto-discovery-templates  ./auto-discovery-templates
 
 # change Java version to 17
-RUN xmlstarlet ed --inplace -N pom=http://maven.apache.org/POM/4.0.0 -u "/pom:project/pom:properties/pom:maven.compiler.source" --value "17" ./pom.xml
-RUN xmlstarlet ed --inplace -N pom=http://maven.apache.org/POM/4.0.0 -u "/pom:project/pom:properties/pom:maven.compiler.target" --value "17" ./pom.xml
+RUN xmlstarlet ed --inplace -N pom=http://maven.apache.org/POM/4.0.0 -u "/pom:project/pom:properties/pom:maven.compiler.source" --value "21" ./pom.xml
+RUN xmlstarlet ed --inplace -N pom=http://maven.apache.org/POM/4.0.0 -u "/pom:project/pom:properties/pom:maven.compiler.target" --value "21" ./pom.xml
 
 # download dependencies
 RUN mvn dependency:go-offline
@@ -38,7 +38,7 @@ RUN mvn clean package -DskipTests
 
 # Stage 2: Create the final image to run the application
 FROM $BUILD_FROM
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=21
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Thanks for the fork and fixing the issue on this one. My sensors stopped working last week and then I stumbled on this fork which works but since I'm on the latest HAOS 2025.9.1 I was running into errors as Java 17 was not available and hence had to update to Java 21. Tested only on my HomeAssistant Yellow with HAOS 2025.9.1